### PR TITLE
[ BUG ] Assistant not working when creating local file links in markdown

### DIFF
--- a/vscode-markdown-assistant/src/completions.ts
+++ b/vscode-markdown-assistant/src/completions.ts
@@ -1,215 +1,409 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, CompletionList, DocumentSelector, Position, Range, SnippetString, TextDocument, workspace } from 'vscode';
+import * as fs from "fs";
+import * as path from "path";
+import {
+  CancellationToken,
+  CompletionContext,
+  CompletionItem,
+  CompletionItemKind,
+  CompletionItemProvider,
+  CompletionList,
+  DocumentSelector,
+  Position,
+  Range,
+  SnippetString,
+  TextDocument,
+  workspace,
+} from "vscode";
 
 /**
  * Source: https://github.com/salesforcedevs/dsc-components/blob/main/packages/%40salesforcedevs/docs-components/src/modules/docHelpers/imgStyle/imgStyle.css
  */
-export const imageClasses = ["image-xxl", "image-full", "image-xl", "image-lg", "image-md", "image-sm", "image-xs", "image-xxs", "image-icon-lg", "image-icon-md", "image-icon-sm", "image-framed", "image-framed-light"]
+export const imageClasses = [
+  "image-xxl",
+  "image-full",
+  "image-xl",
+  "image-lg",
+  "image-md",
+  "image-sm",
+  "image-xs",
+  "image-xxs",
+  "image-icon-lg",
+  "image-icon-md",
+  "image-icon-sm",
+  "image-framed",
+  "image-framed-light",
+];
 
 let EXCLUDE_GLOB: string;
 
 export const Document_Selector_Markdown: DocumentSelector = [
-       { language: "markdown", scheme: "file" },
-       { language: "markdown", scheme: "untitled" },
+  { language: "markdown", scheme: "file" },
+  { language: "markdown", scheme: "untitled" },
 ];
 
 const customPlugins = [
-    {label: '::include', insertText: new SnippetString(`\n::include{src="$1"}\n`)},
-    {label: '::video(VidYard)', insertText: new SnippetString(`\n::video{src="$1" title="$2" type="vidyard"}\n`)},
-    {label: '::video(Youtube)', insertText: new SnippetString(`\n::video{src="$1" title="$2" type="youtube"}\n`)},
-    {label: '::video(Local)', insertText: new SnippetString(`\n::video{src="$1" title="$2" type="local"}\n`)},
-    {label: ':::caution', insertText: new SnippetString(`\n:::caution\n$1\n:::\n`)},
-    {label: ':::tip', insertText: new SnippetString(`\n:::tip\n$1\n:::\n`)},
-    {label: ':::note', insertText: new SnippetString(`\n:::note\n$1\n:::\n`)},
-    {label: ':::warning', insertText: new SnippetString(`\n:::warning\n$1\n:::\n`)},
-    {label: ':::important', insertText: new SnippetString(`\n:::important\n$1\n:::\n`)},
-    {label: '```sfdocs-code', insertText: new SnippetString('\n```sfdocs-code {"lang":"$1", "title": "$2", "src": "$3" }\n\n```\n')},
-    {label: '```Codeblock```', insertText: new SnippetString('\n```\n$1\n```\n')},
-    {label: '-description list', insertText: new SnippetString('\n- First Term\n\n\t- : This text defines the first term.\n')},
-    {label: 'sfdocs image', insertText: new SnippetString(`![alt]($1 '{"class": "$2", "title": "$3"}')\n`), needReplaceRange: false}
+  {
+    label: "::include",
+    insertText: new SnippetString(`\n::include{src="$1"}\n`),
+  },
+  {
+    label: "::video(VidYard)",
+    insertText: new SnippetString(
+      `\n::video{src="$1" title="$2" type="vidyard"}\n`
+    ),
+  },
+  {
+    label: "::video(Youtube)",
+    insertText: new SnippetString(
+      `\n::video{src="$1" title="$2" type="youtube"}\n`
+    ),
+  },
+  {
+    label: "::video(Local)",
+    insertText: new SnippetString(
+      `\n::video{src="$1" title="$2" type="local"}\n`
+    ),
+  },
+  {
+    label: ":::caution",
+    insertText: new SnippetString(`\n:::caution\n$1\n:::\n`),
+  },
+  { label: ":::tip", insertText: new SnippetString(`\n:::tip\n$1\n:::\n`) },
+  { label: ":::note", insertText: new SnippetString(`\n:::note\n$1\n:::\n`) },
+  {
+    label: ":::warning",
+    insertText: new SnippetString(`\n:::warning\n$1\n:::\n`),
+  },
+  {
+    label: ":::important",
+    insertText: new SnippetString(`\n:::important\n$1\n:::\n`),
+  },
+  {
+    label: "```sfdocs-code",
+    insertText: new SnippetString(
+      '\n```sfdocs-code {"lang":"$1", "title": "$2", "src": "$3" }\n\n```\n'
+    ),
+  },
+  {
+    label: "```Codeblock```",
+    insertText: new SnippetString("\n```\n$1\n```\n"),
+  },
+  {
+    label: "-description list",
+    insertText: new SnippetString(
+      "\n- First Term\n\n\t- : This text defines the first term.\n"
+    ),
+  },
+  {
+    label: "sfdocs image",
+    insertText: new SnippetString(
+      `![alt]($1 '{"class": "$2", "title": "$3"}')\n`
+    ),
+    needReplaceRange: false,
+  },
 ];
 
+class MdCompletionItem extends CompletionItem {
+  document: TextDocument;
+  position: Position;
+  constructor(
+    position: Position,
+    document: TextDocument,
+    name: string,
+    kind: CompletionItemKind
+  ) {
+    super(name);
+    this.kind = kind;
+    this.position = position;
+    this.document = document;
+
+    const text = document.getText(
+      new Range(
+        position.line,
+        Math.max(0, position.character - name.length),
+        position.line,
+        position.character
+      )
+    );
+    //replace the entire previously typed path by setting the range to start from the first text after "("
+    const replacementStart = text.indexOf("(") + 1;
+    this.range = new Range(
+      position.line,
+      replacementStart,
+      position.line,
+      position.character
+    );
+  }
+}
+
 export class MdCompletionItemProvider implements CompletionItemProvider {
-    
-    constructor(){
-        // Pretend to support multi-workspacefolders
-        let resource = null;
-        if (workspace.workspaceFolders !== undefined && workspace.workspaceFolders.length > 0) {
-            resource = workspace.workspaceFolders[0].uri;
-        }
-
-        let excludePatterns = ['**/node_modules', '**/bower_components', '**/*.code-search'];
-        if (workspace.getConfiguration('completion', resource).get<boolean>('respectVscodeSearchExclude')) {
-            const configExclude = workspace.getConfiguration('search', resource).get<object>('exclude');
-            for (const key of Object.keys(configExclude!)) {
-                //@ts-ignore
-                if (configExclude[key] === true) {
-                    excludePatterns.push(key);
-                }
-            }
-        }
-
-        excludePatterns = Array.from(new Set(excludePatterns));
-        EXCLUDE_GLOB = '{' + excludePatterns.join(',') + '}';
+  constructor() {
+    // Pretend to support multi-workspacefolders
+    let resource = null;
+    if (
+      workspace.workspaceFolders !== undefined &&
+      workspace.workspaceFolders.length > 0
+    ) {
+      resource = workspace.workspaceFolders[0].uri;
     }
 
-    async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, _context: CompletionContext): Promise<CompletionItem[] | CompletionList<CompletionItem> | undefined> {
-        const lineTextBefore = document.lineAt(position.line).text.substring(0, position.character);
-        const lineTextAfter = document.lineAt(position.line).text.substring(position.character);
-        
-        //file suggestions
-        if (workspace.getWorkspaceFolder(document.uri) === undefined) {
-            return [];
+    let excludePatterns = [
+      "**/node_modules",
+      "**/bower_components",
+      "**/*.code-search",
+    ];
+    if (
+      workspace
+        .getConfiguration("completion", resource)
+        .get<boolean>("respectVscodeSearchExclude")
+    ) {
+      const configExclude = workspace
+        .getConfiguration("search", resource)
+        .get<object>("exclude");
+      for (const key of Object.keys(configExclude!)) {
+        //@ts-ignore
+        if (configExclude[key] === true) {
+          excludePatterns.push(key);
         }
-        let typedDir: string;
-        if (/!\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore) || /<img [^>]*src="[^"]*$/.test(lineTextBefore)) {
-            /* Check if user is trying enter image class */
-            if (/!\[[^\]]*?\]\([^\}\)]*"class":\s?"/.test(lineTextBefore)) {
-                /**
-                 * Find the end position of `"class": "` to keep the selected class after it.
-                 */
-                const classRegex = /"class":\s?"/;
-                const matchItems = lineTextBefore.match(classRegex);
-                let match = lineTextBefore.search(classRegex);
-                if (matchItems?.length) {
-                    match = match + matchItems[0].length;
-                }
-                let replaceRange: Range = new Range(position.line, match, position.line, position.character);
-                return imageClasses.map((imageClass) => {
-                    const completionItem = new CompletionItem(imageClass, CompletionItemKind.Constant);
-                    completionItem.range = replaceRange;
-                    return completionItem;
-                });
-            } else {
-                if (/!\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore)) {
-                    typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('](') + 2);
-                } else {
-                    typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('="') + 2);
-                }
-                const imageExtensions = ['png','jpg','jpeg','svg','gif','webp'];
-    
-                return getFileSuggestions(imageExtensions, document, typedDir);
-            }
-        }else if(/\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore) || /::include{src="/.test(lineTextBefore)){
-            if(/\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore)){
-                typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('](') + 2);
-            }else{
-                typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 5);
-            }
-            
-            return getFileSuggestions(['md'], document, typedDir);
-        }else if(/::video{src="/.test(lineTextBefore) && /type="local"/.test(lineTextAfter)){
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 5);
-            
-            return getFileSuggestions(['mp4','mov'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"java", "title": ".*", "src": "/.test(lineTextBefore)){
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['java'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"py", "title": ".*", "src": "/.test(lineTextBefore)
-            || /sfdocs-code {"lang":"python", "title": ".*", "src": "/.test(lineTextBefore)){
+      }
+    }
 
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['py'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"text", "title": ".*", "src": "/.test(lineTextBefore)
-            || /sfdocs-code {"lang":"txt", "title": ".*", "src": "/.test(lineTextBefore)){
+    excludePatterns = Array.from(new Set(excludePatterns));
+    EXCLUDE_GLOB = "{" + excludePatterns.join(",") + "}";
+  }
 
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['txt'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"js", "title": ".*", "src": "/.test(lineTextBefore)
-            || /sfdocs-code {"lang":"javascript", "title": ".*", "src": "/.test(lineTextBefore)){
+  async provideCompletionItems(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+    _context: CompletionContext
+  ): Promise<CompletionItem[] | CompletionList<CompletionItem> | undefined> {
+    const lineTextBefore = document
+      .lineAt(position.line)
+      .text.substring(0, position.character);
+    const lineTextAfter = document
+      .lineAt(position.line)
+      .text.substring(position.character);
 
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['js'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"markdown", "title": ".*", "src": "/.test(lineTextBefore)
-            || /sfdocs-code {"lang":"md", "title": ".*", "src": "/.test(lineTextBefore)){
-
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['md'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"c", "title": ".*", "src": "/.test(lineTextBefore)
-            || /sfdocs-code {"lang":"C", "title": ".*", "src": "/.test(lineTextBefore)){
-
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['c'], document, typedDir);
-        }else if(/sfdocs-code {"lang":"apex", "title": ".*", "src": "/.test(lineTextBefore)){
-
-            typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf('src') + 7);
-            
-            return getFileSuggestions(['apex'], document, typedDir);
-        }
+    //file suggestions
+    if (workspace.getWorkspaceFolder(document.uri) === undefined) {
+      return [];
+    }
+    let typedDir: string;
+    if (
+      /!\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore) ||
+      /<img [^>]*src="[^"]*$/.test(lineTextBefore)
+    ) {
+      /* Check if user is trying enter image class */
+      if (/!\[[^\]]*?\]\([^\}\)]*"class":\s?"/.test(lineTextBefore)) {
         /**
-         * Custom plugin suggestions
-         * Added s,i for "sfdocs image"
+         * Find the end position of `"class": "` to keep the selected class after it.
          */
-        else if(/(:)|(::)|(:::)|(`)|(``)|(-)|(```)|(s)|(i)$/.test(lineTextBefore)){
-            let match = lineTextBefore.search(/(:)|(::)|(:::)|(`)|(``)|(-)|(```)|$/);
-            let replaceRange: Range = new Range(position.line, match, position.line, position.character);
-            return customPluginSuggestions(replaceRange);
+        const classRegex = /"class":\s?"/;
+        const matchItems = lineTextBefore.match(classRegex);
+        let match = lineTextBefore.search(classRegex);
+        if (matchItems?.length) {
+          match = match + matchItems[0].length;
         }
-    }
-}
-
-function getFileSuggestions(extensions:string[], document:TextDocument, typedDir:string){
-    const basePath = getBasepath(document, typedDir);
-    const isRootedPath = typedDir.startsWith('/');
-
-    return workspace.findFiles(`**/*.{${extensions.toString()}}`, EXCLUDE_GLOB).then(uris => {
-        let items = uris.map(uri => {
-            const label = path.relative(basePath, uri.fsPath).replace(/\\/g, '/');
-            let item = new CompletionItem(label.replace(/ /g, '%20'), CompletionItemKind.File);
-            
-            item.sortText = label.replace(/\./g, '{');
-
-            return item;
+        let replaceRange: Range = new Range(
+          position.line,
+          match,
+          position.line,
+          position.character
+        );
+        return imageClasses.map((imageClass) => {
+          const completionItem = new CompletionItem(
+            imageClass,
+            CompletionItemKind.Constant
+          );
+          completionItem.range = replaceRange;
+          return completionItem;
         });
-
-        if (isRootedPath) {
-            return items.filter(item => {
-                const label:any = item.label;
-                return !label.startsWith('..');
-            });
+      } else {
+        if (/!\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore)) {
+          typedDir = lineTextBefore.substr(
+            lineTextBefore.lastIndexOf("](") + 2
+          );
         } else {
-            return items;
+          typedDir = lineTextBefore.substr(
+            lineTextBefore.lastIndexOf('="') + 2
+          );
         }
+        const imageExtensions = ["png", "jpg", "jpeg", "svg", "gif", "webp"];
+
+        return getFileSuggestions(imageExtensions, document, typedDir);
+      }
+    } else if (
+      /\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore) ||
+      /::include{src="/.test(lineTextBefore)
+    ) {
+      if (/\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore)) {
+        typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("](") + 2);
+      } else {
+        typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 5);
+      }
+
+      const result = await getFileSuggestions(
+        ["md"],
+        document,
+        typedDir,
+        position
+      );
+
+      return result;
+    } else if (
+      /::video{src="/.test(lineTextBefore) &&
+      /type="local"/.test(lineTextAfter)
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 5);
+
+      return getFileSuggestions(["mp4", "mov"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"java", "title": ".*", "src": "/.test(lineTextBefore)
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["java"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"py", "title": ".*", "src": "/.test(
+        lineTextBefore
+      ) ||
+      /sfdocs-code {"lang":"python", "title": ".*", "src": "/.test(
+        lineTextBefore
+      )
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["py"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"text", "title": ".*", "src": "/.test(
+        lineTextBefore
+      ) ||
+      /sfdocs-code {"lang":"txt", "title": ".*", "src": "/.test(lineTextBefore)
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["txt"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"js", "title": ".*", "src": "/.test(
+        lineTextBefore
+      ) ||
+      /sfdocs-code {"lang":"javascript", "title": ".*", "src": "/.test(
+        lineTextBefore
+      )
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["js"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"markdown", "title": ".*", "src": "/.test(
+        lineTextBefore
+      ) ||
+      /sfdocs-code {"lang":"md", "title": ".*", "src": "/.test(lineTextBefore)
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["md"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"c", "title": ".*", "src": "/.test(lineTextBefore) ||
+      /sfdocs-code {"lang":"C", "title": ".*", "src": "/.test(lineTextBefore)
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["c"], document, typedDir);
+    } else if (
+      /sfdocs-code {"lang":"apex", "title": ".*", "src": "/.test(lineTextBefore)
+    ) {
+      typedDir = lineTextBefore.substr(lineTextBefore.lastIndexOf("src") + 7);
+
+      return getFileSuggestions(["apex"], document, typedDir);
+    } else if (
+      /**
+       * Custom plugin suggestions
+       * Added s,i for "sfdocs image"
+       */
+      /(:)|(::)|(:::)|(`)|(``)|(-)|(```)|(s)|(i)$/.test(lineTextBefore)
+    ) {
+      let match = lineTextBefore.search(/(:)|(::)|(:::)|(`)|(``)|(-)|(```)|$/);
+      let replaceRange: Range = new Range(
+        position.line,
+        match,
+        position.line,
+        position.character
+      );
+      return customPluginSuggestions(replaceRange);
+    }
+  }
+}
+
+function getFileSuggestions(
+  extensions: string[],
+  document: TextDocument,
+  typedDir: string,
+  position?: Position
+) {
+  const basePath = getBasepath(document, typedDir);
+  const isRootedPath = typedDir.startsWith("/");
+const isMarkdownPath = extensions.toString() === 'md';
+  return workspace
+    .findFiles(`**/*.{${extensions.toString()}}`, EXCLUDE_GLOB)
+    .then((uris) => {
+      let items = uris.map((uri) => {
+        const label = path.relative(basePath, uri.fsPath).replace(/\\/g, "/");
+        let item = isMarkdownPath ? new MdCompletionItem( position!,
+          document,
+          label.replace(/ /g, "%20"),
+          CompletionItemKind.File) : new CompletionItem(
+          label.replace(/ /g, "%20"),
+          CompletionItemKind.File
+        );
+
+        item.sortText = label.replace(/\./g, "{");
+
+        return item;
+      });
+
+      if (isRootedPath) {
+        return items.filter((item) => {
+          const label: any = item.label;
+          return !label.startsWith("..");
+        });
+      } else {
+        return items;
+      }
     });
 }
 
-function customPluginSuggestions(replaceRange: Range){
-    return customPlugins.map(customPlugin => {
-        const item = new CompletionItem(`${customPlugin.label}`);
-        if (customPlugin.needReplaceRange !== false) {
-            item.range = replaceRange;
-        }
-        item.insertText = customPlugin.insertText;
-        return item;
-    });
+function customPluginSuggestions(replaceRange: Range) {
+  return customPlugins.map((customPlugin) => {
+    const item = new CompletionItem(`${customPlugin.label}`);
+    if (customPlugin.needReplaceRange !== false) {
+      item.range = replaceRange;
+    }
+    item.insertText = customPlugin.insertText;
+    return item;
+  });
 }
 
 function getBasepath(doc: TextDocument, dir: string): string {
-    if (dir.includes('/')) {
-        dir = dir.substr(0, dir.lastIndexOf('/') + 1);
-    } else {
-        dir = '';
-    }
-    //@ts-ignore
-    let root = workspace.getWorkspaceFolder(doc.uri).uri.fsPath;
-    const rootFolder = workspace.getConfiguration('completion', doc.uri).get<string>('root', '');
-    if (rootFolder.length > 0 && fs.existsSync(path.join(root, rootFolder))) {
-        root = path.join(root, rootFolder);
-    }
+  if (dir.includes("/")) {
+    dir = dir.substr(0, dir.lastIndexOf("/") + 1);
+  } else {
+    dir = "";
+  }
+  //@ts-ignore
+  let root = workspace.getWorkspaceFolder(doc.uri).uri.fsPath;
+  const rootFolder = workspace
+    .getConfiguration("completion", doc.uri)
+    .get<string>("root", "");
+  if (rootFolder.length > 0 && fs.existsSync(path.join(root, rootFolder))) {
+    root = path.join(root, rootFolder);
+  }
 
-    const basePath = path.join(
-        dir.startsWith('/')
-            ? root
-            : path.dirname(doc.uri.fsPath),
-        dir
-    );
+  const basePath = path.join(
+    dir.startsWith("/") ? root : path.dirname(doc.uri.fsPath),
+    dir
+  );
 
-    return basePath;
+  return basePath;
 }


### PR DESCRIPTION
Title : Assistant not working when creating local file links in markdown

Introduction: This PR aims to address an issue where the assistant incorrectly handles local file links in Markdown, causing them to malfunction.

Changes Made: I have made modifications to the assistant's behavior when creating local file links. Now, when a local file is selected from the dropdown, the link text will correctly display only the selected filename, without appending any previously typed characters.

Benefits/Impact: Users will experience improved functionality when creating local file links in Markdown documents. The assistant will provide the expected behavior, making the process more intuitive and reliable.

Related Issues: None